### PR TITLE
fix equality check by replacing assignment with comparison

### DIFF
--- a/Ext4Fsd/devctl.c
+++ b/Ext4Fsd/devctl.c
@@ -426,14 +426,14 @@ Ext2ProcessVolumeProperty(
         case APP_CMD_SET_PROPERTY2:
 
             RtlZeroMemory(Vcb->sHidingPrefix, HIDINGPAT_LEN);
-            if (Vcb->bHidingPrefix = Property2->bHidingPrefix) {
+            if (Vcb->bHidingPrefix == Property2->bHidingPrefix) {
                 RtlCopyMemory( Vcb->sHidingPrefix,
                                Property2->sHidingPrefix,
                                HIDINGPAT_LEN - 1);
             }
 
             RtlZeroMemory(Vcb->sHidingSuffix, HIDINGPAT_LEN);
-            if (Vcb->bHidingSuffix = Property2->bHidingSuffix) {
+            if (Vcb->bHidingSuffix == Property2->bHidingSuffix) {
                 RtlCopyMemory( Vcb->sHidingSuffix,
                                Property2->sHidingSuffix,
                                HIDINGPAT_LEN - 1);
@@ -511,7 +511,7 @@ Ext2ProcessVolumeProperty(
             RtlCopyMemory(Property2->UUID, Vcb->SuperBlock->s_uuid, 16);
             Property2->DrvLetter = Vcb->DrvLetter;
 
-            if (Property2->bHidingPrefix = Vcb->bHidingPrefix) {
+            if (Property2->bHidingPrefix == Vcb->bHidingPrefix) {
                 RtlCopyMemory( Property2->sHidingPrefix,
                                Vcb->sHidingPrefix,
                                HIDINGPAT_LEN);
@@ -520,7 +520,7 @@ Ext2ProcessVolumeProperty(
                                HIDINGPAT_LEN);
             }
 
-            if (Property2->bHidingSuffix = Vcb->bHidingSuffix) {
+            if (Property2->bHidingSuffix == Vcb->bHidingSuffix) {
                 RtlCopyMemory( Property2->sHidingSuffix,
                                Vcb->sHidingSuffix,
                                HIDINGPAT_LEN);

--- a/Ext4Fsd/memory.c
+++ b/Ext4Fsd/memory.c
@@ -2179,7 +2179,7 @@ Ext2PerformRegistryVolumeParams(IN PEXT2_VCB Vcb)
         memcpy(Vcb->Codepage.AnsiName, Ext2Global->Codepage.AnsiName, CODEPAGE_MAXLEN);
         Vcb->Codepage.PageTable = Ext2Global->Codepage.PageTable;
 
-        if (Vcb->bHidingPrefix = Ext2Global->bHidingPrefix) {
+        if (Vcb->bHidingPrefix == Ext2Global->bHidingPrefix) {
             RtlCopyMemory( Vcb->sHidingPrefix,
                            Ext2Global->sHidingPrefix,
                            HIDINGPAT_LEN);
@@ -2188,7 +2188,7 @@ Ext2PerformRegistryVolumeParams(IN PEXT2_VCB Vcb)
                            HIDINGPAT_LEN);
         }
 
-        if (Vcb->bHidingSuffix = Ext2Global->bHidingSuffix) {
+        if (Vcb->bHidingSuffix == Ext2Global->bHidingSuffix) {
             RtlCopyMemory( Vcb->sHidingSuffix,
                            Ext2Global->sHidingSuffix,
                            HIDINGPAT_LEN);


### PR DESCRIPTION
Fixes coming from [ReactOS](https://github.com/reactos/reactos) .

ReactOS still uses Ext2Fsd instead of Ext4fsd.
However, since Ext2fsd is no longer maintained, I'm upstreaming these fixes here.

I'm not the original author of those fixes.