### PR TITLE
code consistency: align usage of specifiers

### DIFF
--- a/Ext4Fsd/ext4/ext4_extents.c
+++ b/Ext4Fsd/ext4/ext4_extents.c
@@ -2153,7 +2153,7 @@ fix_extent_len:
 /*
  * returns 1 if current index have to be freed (even partial)
  */
-static int inline
+static inline int
 ext4_ext_more_to_rm(struct ext4_ext_path *path)
 {
 	BUG_ON(path->p_idx == NULL);

--- a/Ext4Fsd/include/ext2fs.h
+++ b/Ext4Fsd/include/ext2fs.h
@@ -216,7 +216,7 @@ _InterlockedXor (
 #define SetLongFlag(_F,_SF)   Ext2SetFlag(&(_F), (ULONG)(_SF))
 #define ClearLongFlag(_F,_SF) Ext2ClearFlag(&(_F), (ULONG)(_SF))
 
-__inline
+inline
 VOID
 Ext2SetFlag(PULONG Flags, ULONG FlagBit)
 {
@@ -224,7 +224,7 @@ Ext2SetFlag(PULONG Flags, ULONG FlagBit)
     ASSERT(*Flags == (_ret | FlagBit));
 }
 
-__inline
+inline
 VOID
 Ext2ClearFlag(PULONG Flags, ULONG FlagBit)
 {
@@ -952,7 +952,7 @@ struct _EXT2_MCB {
 #define Ext2ReferXcb(_C)  InterlockedIncrement(_C)
 #define Ext2DerefXcb(_C)  DEC_OBJ_CNT(_C)
 
-__inline ULONG DEC_OBJ_CNT(PULONG _C) {
+inline ULONG DEC_OBJ_CNT(PULONG _C) {
     if (*_C <= 0) {
         DbgBreak();
     }
@@ -1122,7 +1122,7 @@ typedef struct _EXT2_EXTENT {
 // memory allocation statistics
 //
 
-__inline
+inline
 VOID
 Ext2TraceMemory(BOOLEAN _n, int _i, PVOID _p, LONG _s)
 {
@@ -1136,7 +1136,7 @@ Ext2TraceMemory(BOOLEAN _n, int _i, PVOID _p, LONG _s)
     }
 }
 
-__inline
+inline
 VOID
 Ext2TraceIrpContext(BOOLEAN _n, PEXT2_IRP_CONTEXT IrpContext)
 {

--- a/Ext4Fsd/include/linux/ext4.h
+++ b/Ext4Fsd/include/linux/ext4.h
@@ -2219,7 +2219,7 @@ extern struct buffer_head *ext4_read_block_bitmap(struct super_block *sb,
 extern unsigned ext4_free_clusters_after_init(struct super_block *sb,
 					      ext4_group_t block_group,
 					      struct ext4_group_desc *gdp);
-ext4_fsblk_t ext4_inode_to_goal_block(struct inode *);
+static inline ext4_fsblk_t ext4_inode_to_goal_block(struct inode *);
 #if 0
 static inline bool ext4_encrypted_inode(struct inode *inode)
 {
@@ -3370,7 +3370,7 @@ __u32 ext4_chksum(struct ext4_sb_info *sbi, __u32 crc,
 int ext4_superblock_csum_verify(struct super_block *sb,
 				       struct ext4_super_block *es);
 void ext4_superblock_csum_set(struct super_block *sb);
-__le16 ext4_group_desc_csum(struct super_block *sb, __u32 block_group,
+static __le16 ext4_group_desc_csum(struct super_block *sb, __u32 block_group,
 				   struct ext4_group_desc *gdp);
 int ext4_group_desc_csum_verify(struct super_block *sb, __u32 block_group,
 				struct ext4_group_desc *gdp);

--- a/Ext4Fsd/include/linux/module.h
+++ b/Ext4Fsd/include/linux/module.h
@@ -438,10 +438,10 @@ extern struct task_struct *current;
 //
 
 
-static inline cond_resched() {
+static inline int cond_resched() {
     return FALSE;
 }
-static inline need_resched() {
+static inline int need_resched() {
     return FALSE;
 }
 

--- a/Ext4Fsd/memory.c
+++ b/Ext4Fsd/memory.c
@@ -2249,7 +2249,7 @@ Ext2InitializeLabel(
     return status;
 }
 
-static __inline BOOLEAN Ext2IsNullUuid (__u8 * uuid)
+static inline BOOLEAN Ext2IsNullUuid (__u8 * uuid)
 {
     int i;
     for (i = 0; i < 16; i++) {


### PR DESCRIPTION
- always use static inline in the same order
- always use inline instead of __inline
- re-align specifiers between declarations and definitions