### PR TITLE
Ext2Read(): Complete request on VCB_VOLUME_LOCKED case

### DIFF
--- a/Ext4Fsd/read.c
+++ b/Ext4Fsd/read.c
@@ -906,6 +906,7 @@ Ext2Read (IN PEXT2_IRP_CONTEXT IrpContext)
             if (FlagOn(Vcb->Flags, VCB_VOLUME_LOCKED) &&
                 Vcb->LockFile != FileObject ) {
                 Status = STATUS_ACCESS_DENIED;
+                bCompleteRequest = TRUE;
                 __leave;
             }
 


### PR DESCRIPTION
Fix coming from [ReactOS](https://github.com/reactos/reactos).

reactos/reactos#4770

I'm not the original author of this change.