### PR TITLE
Fix system hang on USB/removable device removal

### DIFF
--- a/Ext4Fsd/block.c
+++ b/Ext4Fsd/block.c
@@ -400,8 +400,15 @@ Ext2ReadWriteBlocks(
         }
 
         if (Ext2CanIWait()) {
-            KeWaitForSingleObject( &(pContext->Event),
-                                   Executive, KernelMode, FALSE, NULL );
+            LARGE_INTEGER Timeout;
+            Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
+            Status = KeWaitForSingleObject( &(pContext->Event),
+                                   Executive, KernelMode, FALSE, &Timeout );
+            if (Status == STATUS_TIMEOUT) {
+                /* Device likely removed — unblock and report error */
+                MasterIrp->IoStatus.Status = STATUS_IO_TIMEOUT;
+                MasterIrp->IoStatus.Information = 0;
+            }
             KeClearEvent( &(pContext->Event) );
         } else {
             bMasterCompleted = TRUE;
@@ -496,15 +503,23 @@ Ext2ReadSync(
         Status = IoCallDriver(Vcb->TargetDeviceObject, Irp);
 
         if (Status == STATUS_PENDING) {
-            KeWaitForSingleObject(
+            LARGE_INTEGER Timeout;
+            Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
+            Status = KeWaitForSingleObject(
                 Event,
                 Suspended,
                 KernelMode,
                 FALSE,
-                NULL
+                &Timeout
             );
 
-            Status = IoStatus.Status;
+            if (Status == STATUS_TIMEOUT) {
+                IoCancelIrp(Irp);
+                KeWaitForSingleObject(Event, Executive, KernelMode, FALSE, NULL);
+                Status = STATUS_IO_TIMEOUT;
+            } else {
+                Status = IoStatus.Status;
+            }
         }
 
     } __finally {
@@ -610,8 +625,16 @@ Ext2DiskIoControl (
     Status = IoCallDriver(DeviceObject, Irp);
 
     if (Status == STATUS_PENDING)  {
-        KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
-        Status = IoStatus.Status;
+        LARGE_INTEGER Timeout;
+        Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
+        Status = KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, &Timeout);
+        if (Status == STATUS_TIMEOUT) {
+            IoCancelIrp(Irp);
+            KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+            Status = STATUS_IO_TIMEOUT;
+        } else {
+            Status = IoStatus.Status;
+        }
     }
 
     if (OutputBufferSize) {
@@ -644,13 +667,21 @@ Ext2DiskShutDown(PEXT2_VCB Vcb)
         Status = IoCallDriver(Vcb->TargetDeviceObject, Irp);
 
         if (Status == STATUS_PENDING) {
-            KeWaitForSingleObject(&Event,
+            LARGE_INTEGER Timeout;
+            Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
+            Status = KeWaitForSingleObject(&Event,
                                   Executive,
                                   KernelMode,
                                   FALSE,
-                                  NULL);
+                                  &Timeout);
 
-            Status = IoStatus.Status;
+            if (Status == STATUS_TIMEOUT) {
+                IoCancelIrp(Irp);
+                KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+                Status = STATUS_IO_TIMEOUT;
+            } else {
+                Status = IoStatus.Status;
+            }
         }
     } else  {
         Status = IoStatus.Status;

--- a/Ext4Fsd/fsctl.c
+++ b/Ext4Fsd/fsctl.c
@@ -2019,14 +2019,22 @@ Ext2IsMediaWriteProtected (
     Status = IoCallDriver(TargetDevice, Irp);
 
     if (Status == STATUS_PENDING) {
+        LARGE_INTEGER Timeout;
+        Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
 
-        (VOID) KeWaitForSingleObject( &Event,
+        Status = KeWaitForSingleObject( &Event,
                                       Executive,
                                       KernelMode,
                                       FALSE,
-                                      (PLARGE_INTEGER)NULL );
+                                      &Timeout );
 
-        Status = IoStatus.Status;
+        if (Status == STATUS_TIMEOUT) {
+            IoCancelIrp(Irp);
+            KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+            Status = STATUS_IO_TIMEOUT;
+        } else {
+            Status = IoStatus.Status;
+        }
     }
 
     return (BOOLEAN)(Status == STATUS_MEDIA_WRITE_PROTECTED);

--- a/Ext4Fsd/pnp.c
+++ b/Ext4Fsd/pnp.c
@@ -249,6 +249,9 @@ Ext2PnpRemove (
         Status = Ext2LockVcb(Vcb, IrpContext->FileObject);
         ExReleaseResourceLite(&Vcb->MainResource);
 
+        /* Mark device removed early so concurrent I/O threads fail fast */
+        SetLongFlag(Vcb->Flags, VCB_DEVICE_REMOVED);
+
         //
         // Setup the Irp. We'll send it to the lower disk driver.
         //
@@ -282,7 +285,6 @@ Ext2PnpRemove (
 
         /* dismount volume */
         bDeleted = Ext2CheckDismount(IrpContext, Vcb, TRUE);
-        SetLongFlag(Vcb->Flags, VCB_DEVICE_REMOVED);
 
     } __finally {
 
@@ -319,6 +321,9 @@ Ext2PnpSurpriseRemove (
 
         ExReleaseResourceLite(&Vcb->MainResource);
 
+        /* Mark device removed early so concurrent I/O threads fail fast */
+        SetLongFlag(Vcb->Flags, VCB_DEVICE_REMOVED);
+
         //
         // Setup the Irp. We'll send it to the lower disk driver.
         //
@@ -352,7 +357,6 @@ Ext2PnpSurpriseRemove (
 
         /* dismount volume */
         bDeleted = Ext2CheckDismount(IrpContext, Vcb, TRUE);
-        SetLongFlag(Vcb->Flags, VCB_DEVICE_REMOVED);
 
     } __finally {
 

--- a/Ext4Fsd/pnp.c
+++ b/Ext4Fsd/pnp.c
@@ -198,11 +198,20 @@ Ext2PnpQueryRemove (
                                IrpContext->Irp);
 
         if (Status == STATUS_PENDING) {
-            KeWaitForSingleObject( &Event,
+            LARGE_INTEGER Timeout;
+            Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
+
+            Status = KeWaitForSingleObject( &Event,
                                    Executive,
                                    KernelMode,
                                    FALSE,
-                                   NULL );
+                                   &Timeout );
+
+            if (Status == STATUS_TIMEOUT) {
+                IoCancelIrp(IrpContext->Irp);
+                KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+            }
+
             Status = IrpContext->Irp->IoStatus.Status;
         }
 
@@ -270,12 +279,19 @@ Ext2PnpRemove (
                                IrpContext->Irp);
 
         if (Status == STATUS_PENDING) {
+            LARGE_INTEGER Timeout;
+            Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
 
-            KeWaitForSingleObject( &Event,
+            Status = KeWaitForSingleObject( &Event,
                                    Executive,
                                    KernelMode,
                                    FALSE,
-                                   NULL );
+                                   &Timeout );
+
+            if (Status == STATUS_TIMEOUT) {
+                IoCancelIrp(IrpContext->Irp);
+                KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+            }
 
             Status = IrpContext->Irp->IoStatus.Status;
         }
@@ -342,12 +358,19 @@ Ext2PnpSurpriseRemove (
                                IrpContext->Irp);
 
         if (Status == STATUS_PENDING) {
+            LARGE_INTEGER Timeout;
+            Timeout.QuadPart = (LONGLONG)-30 * 10 * 1000 * 1000; /* 30 seconds */
 
-            KeWaitForSingleObject( &Event,
+            Status = KeWaitForSingleObject( &Event,
                                    Executive,
                                    KernelMode,
                                    FALSE,
-                                   NULL );
+                                   &Timeout );
+
+            if (Status == STATUS_TIMEOUT) {
+                IoCancelIrp(IrpContext->Irp);
+                KeWaitForSingleObject(&Event, Executive, KernelMode, FALSE, NULL);
+            }
 
             Status = IrpContext->Irp->IoStatus.Status;
         }

--- a/Ext4Fsd/read.c
+++ b/Ext4Fsd/read.c
@@ -879,6 +879,12 @@ Ext2Read (IN PEXT2_IRP_CONTEXT IrpContext)
 
             FileObject = IrpContext->FileObject;
 
+            if (IsFlagOn(Vcb->Flags, VCB_DEVICE_REMOVED)) {
+                Status = STATUS_NO_SUCH_DEVICE;
+                bCompleteRequest = TRUE;
+                __leave;
+            }
+
             if (FlagOn(Vcb->Flags, VCB_VOLUME_LOCKED) &&
                 Vcb->LockFile != FileObject ) {
                 Status = STATUS_ACCESS_DENIED;

--- a/Ext4Fsd/write.c
+++ b/Ext4Fsd/write.c
@@ -1359,6 +1359,11 @@ Ext2Write (IN PEXT2_IRP_CONTEXT IrpContext)
                 __leave;
             }
 
+            if (IsFlagOn(Vcb->Flags, VCB_DEVICE_REMOVED)) {
+                Status = STATUS_NO_SUCH_DEVICE;
+                __leave;
+            }
+
             if (FlagOn(Vcb->Flags, VCB_VOLUME_LOCKED) &&
                 Vcb->LockFile != FileObject ) {
                 Status = STATUS_ACCESS_DENIED;


### PR DESCRIPTION
## Summary

- **block.c**: Add 30-second timeouts to all `KeWaitForSingleObject` calls that wait for I/O completion. On timeout, cancel pending IRPs via `IoCancelIrp` and return `STATUS_IO_TIMEOUT` instead of hanging forever.
- **pnp.c**: Move `SetLongFlag(Vcb->Flags, VCB_DEVICE_REMOVED)` earlier in both `Ext2PnpRemove` and `Ext2PnpSurpriseRemove`, before sending the IRP down and dismounting. Add 30-second timeouts to the PnP IRP waits in Remove, SurpriseRemove, and QueryRemove paths.
- **fsctl.c**: Add 30-second timeout to `Ext2IsMediaWriteProtected` which also waited indefinitely for the lower driver.
- **read.c / write.c**: Add `VCB_DEVICE_REMOVED` flag checks early in `Ext2Read` and `Ext2Write`, returning `STATUS_NO_SUCH_DEVICE` immediately to prevent new I/O from being issued to a removed device.

## Problem

When a USB drive formatted with ext2/ext3/ext4 is physically removed while the Ext4Fsd driver has outstanding I/O, the system hangs indefinitely. This happens because `KeWaitForSingleObject` calls across multiple code paths wait with `NULL` timeout (infinite) for I/O completions that will never arrive from the now-removed device. Additionally, the `VCB_DEVICE_REMOVED` flag was set too late in the PnP removal path, after dismount, so concurrent threads had no way to detect the removal early.